### PR TITLE
Add download page

### DIFF
--- a/contributing/index.html
+++ b/contributing/index.html
@@ -18,6 +18,7 @@
 <small>
 [<a href="http://gdcproject.org">home</a>]
 [<a href="http://gdcproject.org/contributing">contributing</a>]
+[<a href="http://gdcproject.org/downloads">downloads</a>]
 [<a href="http://gdcproject.org/documentation">documentation</a>]
 [<a href="http://bugzilla.gdcproject.org">bugs</a>]
 [<a href="https://github.com/D-Programming-GDC/GDC">current git</a>]

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -18,6 +18,7 @@
 <small>
 [<a href="http://gdcproject.org">home</a>]
 [<a href="http://gdcproject.org/contributing">contributing</a>]
+[<a href="http://gdcproject.org/downloads">downloads</a>]
 [<a href="http://gdcproject.org/documentation">documentation</a>]
 [<a href="http://bugzilla.gdcproject.org">bugs</a>]
 [<a href="https://github.com/D-Programming-GDC/GDC">current git</a>]

--- a/downloads/index.html
+++ b/downloads/index.html
@@ -1,0 +1,348 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html>
+
+<head>
+<meta content="text/html; charset=ISO-8859-1" http-equiv="content-type">
+<meta name="keywords" content="GNU D Compiler, GDC, D programming language">
+<meta name="description" content="GNU D Compiler">
+<link rel="stylesheet" href="/style/main.css" type="text/css" media="all" charset="utf-8">
+<link rel="shortcut icon" href="/images/favicon.ico" type="image/x-icon">
+<title>GDC - D Programming Language for GCC</title>
+</head>
+
+<body>
+
+<center><a href="/"><img src="/images/gdc-logo.png" alt="GDC Project Revived" width="200px"></a></center>
+
+<center>
+<small>
+[<a href="http://gdcproject.org">home</a>]
+[<a href="http://gdcproject.org/contributing">contributing</a>]
+[<a href="http://gdcproject.org/documentation">documentation</a>]
+[<a href="http://bugzilla.gdcproject.org">bugs</a>]
+[<a href="https://github.com/D-Programming-GDC/GDC">current git</a>]
+[<a href="http://forum.dlang.org/group/D.gnu">mailing lists</a>]
+[<a href="http://wiki.gdcproject.org">wiki</a>]
+</small>
+</center>
+
+<a href="https://github.com/D-Programming-GDC">
+<img style="position: absolute; top: 0; right: 0; border: 0;"
+     src="/images/github-ribbon.png" alt="Fork me on GitHub">
+</a>
+
+<div class="page">
+<h3>Source code</h3>
+
+<p>For access to the current development sources of GDC, visit
+<a href="https://github.com/D-Programming-GDC/GDC">our git repository</a>.
+
+<h3>Linux distribution packages</h3>
+<p> Official packages are available for these linux distributions:
+<ul>
+  <li><a href="https://www.archlinux.org/packages/?sort=&arch=i686&arch=x86_64&q=gdc">Arch Linux</a></li>
+  <li><a href="http://packages.ubuntu.com/search?keywords=gdc&searchon=names&exact=1&suite=all&section=all">Ubuntu</a></li>
+</ul>
+
+<h3>Binary releases</h3>
+
+<p> This page contains native and cross compilers. A native compiler creates executables for the system it runs on.
+A cross-compiler runs on 'host' and generates code for 'target'. The headings on this page specify the compiler 'host',
+the entries in the Target column specify the 'target'.
+
+<h4>Windows X86 32bit (i686-w64-mingw32)</h4>
+<div class="hostBox">
+<div class="dlBox">
+  <div class="dlTarget">Daniel Green's builds</div>
+  <table>
+  <tr>
+    <th class="dlHostCol"></th>
+    <th class="dlCommentCol">Comment</th>
+    <th>DMDFE</th>
+    <th>Runtime</th>
+    <th>GCC</th>
+    <th>Multilib</th>
+    <th>GDC revision</th>
+    <th>Build Date</th>
+    <th></th>
+  </tr>
+  <tr>
+    <td>TDM64</td>
+    <td></td>
+    <td>2.058</td>
+    <td>yes</td>
+    <td>4.6.1</td>
+    <td>-m32<br>-m64</td>
+    <td>6a4bafe80b</td>
+    <td>2012-07-08</td>
+    <td><a href="http://gdcproject.org/downloads/binaries/i686-w64-mingw32/dgreen/gcc-4.6.1-tdm64-1-gdc-6a4bafe80b-20120708-D2.058.7z">Download</a></td>
+  </tr>
+  </table>
+</div>
+<div class="dlBox">
+  <div class="dlTarget">Standard builds</div>
+  <table>
+  <tr>
+    <th class="dlHostCol">Target</th>
+    <th class="dlCommentCol">Comment</th>
+    <th>DMDFE</th>
+    <th>Runtime</th>
+    <th>GCC</th>
+    <th>Multilib</th>
+    <th>GDC revision</th>
+    <th>Build Date</th>
+    <th></th>
+  </tr>
+  <tr>
+    <td>arm-linux-gnueabihf</td>
+    <td></td>
+    <td>2.064.2</td>
+    <td>yes</td>
+    <td>4.8.2</td>
+    <td></td>
+    <td>665978132e</td>
+    <td>2014-03-12</td>
+    <td><a href="http://gdcproject.org/downloads/binaries/i686-w64-mingw32/arm-linux-gnueabihf_2.064.2_gcc4.8.2_665978132e_20140312.7z">Download</a></td>
+  </tr>
+  <tr>
+    <td>arm-linux-gnueabi</td>
+    <td></td>
+    <td>2.064.2</td>
+    <td>yes</td>
+    <td>4.8.2</td>
+    <td></td>
+    <td>665978132e</td>
+    <td>2014-03-12</td>
+    <td><a href="http://gdcproject.org/downloads/binaries/i686-w64-mingw32/arm-linux-gnueabi_2.064.2_gcc4.8.2_665978132e_20140312.7z">Download</a></td>
+  </tr>
+  </table>
+</div>
+<a class="archiveLink" href="ftp://ftp.gdcproject.org/binaries/i686-w64-mingw32/">Release archive</a>
+</div>
+<h4>Windows X86 64bit (x86_64-w64-mingw32)</h4>
+<div class="hostBox">
+<div class="dlBox">
+  <div class="dlTarget">Standard builds</div>
+  <table>
+  <tr>
+    <th class="dlHostCol">Target</th>
+    <th class="dlCommentCol">Comment</th>
+    <th>DMDFE</th>
+    <th>Runtime</th>
+    <th>GCC</th>
+    <th>Multilib</th>
+    <th>GDC revision</th>
+    <th>Build Date</th>
+    <th></th>
+  </tr>
+  <tr>
+    <td>arm-linux-gnueabihf</td>
+    <td></td>
+    <td>2.064.2</td>
+    <td>yes</td>
+    <td>4.8.2</td>
+    <td></td>
+    <td>665978132e</td>
+    <td>2014-03-12</td>
+    <td><a href="http://gdcproject.org/downloads/binaries/x86_64-w64-mingw32/arm-linux-gnueabihf_2.064.2_gcc4.8.2_665978132e_20140312.7z">Download</a></td>
+  </tr>
+  <tr>
+    <td>arm-linux-gnueabi</td>
+    <td></td>
+    <td>2.064.2</td>
+    <td>yes</td>
+    <td>4.8.2</td>
+    <td></td>
+    <td>665978132e</td>
+    <td>2014-03-12</td>
+    <td><a href="http://gdcproject.org/downloads/binaries/x86_64-w64-mingw32/arm-linux-gnueabi_2.064.2_gcc4.8.2_665978132e_20140312.7z">Download</a></td>
+  </tr>
+  </table>
+</div>
+<a class="archiveLink" href="ftp://ftp.gdcproject.org/binaries/x86_64-w64-mingw32/">Release archive</a>
+</div>
+<h4>Linux X86 32bit (i686-linux-gnu)</h4>
+<div class="hostBox">
+<div class="dlBox">
+  <div class="dlTarget">Standard builds</div>
+  <table>
+  <tr>
+    <th class="dlHostCol">Target</th>
+    <th class="dlCommentCol">Comment</th>
+    <th>DMDFE</th>
+    <th>Runtime</th>
+    <th>GCC</th>
+    <th>Multilib</th>
+    <th>GDC revision</th>
+    <th>Build Date</th>
+    <th></th>
+  </tr>
+  <tr>
+    <td>native</td>
+    <td></td>
+    <td>2.064.2</td>
+    <td>yes</td>
+    <td>4.8.2</td>
+    <td></td>
+    <td>665978132e</td>
+    <td>2014-03-09</td>
+    <td><a href="http://gdcproject.org/downloads/binaries/i686-linux-gnu/native_2.064.2_gcc4.8.2_665978132e_20140309.tar.xz">Download</a></td>
+  </tr>
+  <tr>
+    <td>arm-linux-gnueabihf</td>
+    <td></td>
+    <td>2.064.2</td>
+    <td>yes</td>
+    <td>4.8.2</td>
+    <td></td>
+    <td>665978132e</td>
+    <td>2014-03-12</td>
+    <td><a href="http://gdcproject.org/downloads/binaries/i686-linux-gnu/arm-linux-gnueabihf_2.064.2_gcc4.8.2_665978132e_20140312.tar.xz">Download</a></td>
+  </tr>
+  <tr>
+    <td>arm-linux-gnueabi</td>
+    <td></td>
+    <td>2.064.2</td>
+    <td>yes</td>
+    <td>4.8.2</td>
+    <td></td>
+    <td>665978132e</td>
+    <td>2014-03-12</td>
+    <td><a href="http://gdcproject.org/downloads/binaries/i686-linux-gnu/arm-linux-gnueabi_2.064.2_gcc4.8.2_665978132e_20140312.tar.xz">Download</a></td>
+  </tr>
+  </table>
+</div>
+<a class="archiveLink" href="ftp://ftp.gdcproject.org/binaries/i686-linux-gnu/">Release archive</a>
+</div>
+<h4>Linux X86 64bit (x86_64-linux-gnu)</h4>
+<div class="hostBox">
+<div class="dlBox">
+  <div class="dlTarget">Standard builds</div>
+  <table>
+  <tr>
+    <th class="dlHostCol">Target</th>
+    <th class="dlCommentCol">Comment</th>
+    <th>DMDFE</th>
+    <th>Runtime</th>
+    <th>GCC</th>
+    <th>Multilib</th>
+    <th>GDC revision</th>
+    <th>Build Date</th>
+    <th></th>
+  </tr>
+  <tr>
+    <td>native</td>
+    <td></td>
+    <td>2.064.2</td>
+    <td>yes</td>
+    <td>4.8.2</td>
+    <td></td>
+    <td>665978132e</td>
+    <td>2014-03-09</td>
+    <td><a href="http://gdcproject.org/downloads/binaries/x86_64-linux-gnu/native_2.064.2_gcc4.8.2_665978132e_20140309.tar.xz">Download</a></td>
+  </tr>
+  <tr>
+    <td>i686-linux-gnu</td>
+    <td></td>
+    <td>2.064.2</td>
+    <td>yes</td>
+    <td>4.8.2</td>
+    <td></td>
+    <td>665978132e</td>
+    <td>2014-03-09</td>
+    <td><a href="http://gdcproject.org/downloads/binaries/x86_64-linux-gnu/i686-linux-gnu_2.064.2_gcc4.8.2_665978132e_20140309.tar.xz">Download</a></td>
+  </tr>
+  <tr>
+    <td>arm-linux-gnueabihf</td>
+    <td></td>
+    <td>2.064.2</td>
+    <td>yes</td>
+    <td>4.8.2</td>
+    <td></td>
+    <td>665978132e</td>
+    <td>2014-03-12</td>
+    <td><a href="http://gdcproject.org/downloads/binaries/x86_64-linux-gnu/arm-linux-gnueabihf_2.064.2_gcc4.8.2_665978132e_20140312.tar.xz">Download</a></td>
+  </tr>
+  <tr>
+    <td>arm-linux-gnueabi</td>
+    <td></td>
+    <td>2.064.2</td>
+    <td>yes</td>
+    <td>4.8.2</td>
+    <td></td>
+    <td>665978132e</td>
+    <td>2014-03-12</td>
+    <td><a href="http://gdcproject.org/downloads/binaries/x86_64-linux-gnu/arm-linux-gnueabi_2.064.2_gcc4.8.2_665978132e_20140312.tar.xz">Download</a></td>
+  </tr>
+  </table>
+</div>
+<a class="archiveLink" href="ftp://ftp.gdcproject.org/binaries/x86_64-linux-gnu/">Release archive</a>
+</div>
+<h4>Linux ARM (hardfloat) (arm-linux-gnueabihf)</h4>
+<div class="hostBox">
+<div class="dlBox">
+  <div class="dlTarget">Standard builds</div>
+  <table>
+  <tr>
+    <th class="dlHostCol">Target</th>
+    <th class="dlCommentCol">Comment</th>
+    <th>DMDFE</th>
+    <th>Runtime</th>
+    <th>GCC</th>
+    <th>Multilib</th>
+    <th>GDC revision</th>
+    <th>Build Date</th>
+    <th></th>
+  </tr>
+  <tr>
+    <td>native</td>
+    <td></td>
+    <td>2.064.2</td>
+    <td>yes</td>
+    <td>4.8.2</td>
+    <td></td>
+    <td>665978132e</td>
+    <td>2014-03-12</td>
+    <td><a href="http://gdcproject.org/downloads/binaries/arm-linux-gnueabihf/native_2.064.2_gcc4.8.2_665978132e_20140312.tar.xz">Download</a></td>
+  </tr>
+  </table>
+</div>
+<a class="archiveLink" href="ftp://ftp.gdcproject.org/binaries/arm-linux-gnueabihf/">Release archive</a>
+</div>
+<h4>Linux ARM (softfloat) (arm-linux-gnueabi)</h4>
+<div class="hostBox">
+<div class="dlBox">
+  <div class="dlTarget">Standard builds</div>
+  <table>
+  <tr>
+    <th class="dlHostCol">Target</th>
+    <th class="dlCommentCol">Comment</th>
+    <th>DMDFE</th>
+    <th>Runtime</th>
+    <th>GCC</th>
+    <th>Multilib</th>
+    <th>GDC revision</th>
+    <th>Build Date</th>
+    <th></th>
+  </tr>
+  <tr>
+    <td>native</td>
+    <td></td>
+    <td>2.064.2</td>
+    <td>yes</td>
+    <td>4.8.2</td>
+    <td></td>
+    <td>665978132e</td>
+    <td>2014-03-12</td>
+    <td><a href="http://gdcproject.org/downloads/binaries/arm-linux-gnueabi/native_2.064.2_gcc4.8.2_665978132e_20140312.tar.xz">Download</a></td>
+  </tr>
+  </table>
+</div>
+<a class="archiveLink" href="ftp://ftp.gdcproject.org/binaries/arm-linux-gnueabi/">Release archive</a>
+</div>
+
+</div>
+
+</body>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
 <small>
 [<a href="http://gdcproject.org">home</a>]
 [<a href="http://gdcproject.org/contributing">contributing</a>]
+[<a href="http://gdcproject.org/downloads">downloads</a>]
 [<a href="http://gdcproject.org/documentation">documentation</a>]
 [<a href="http://bugzilla.gdcproject.org">bugs</a>]
 [<a href="https://github.com/D-Programming-GDC/GDC">current git</a>]

--- a/style/main.css
+++ b/style/main.css
@@ -12,6 +12,11 @@ h3 {
   padding: 8px 0 0 0;
   margin: 1.5em 0 0 0;
 }
+h4 {
+  border-bottom: 1px dotted #ddd;
+  padding: 4px 0 0 0;
+  margin: 1em 0 0 0;
+}
 center {
   padding: 8px 0 0 0;
   margin: 1.5em 0 0 0;
@@ -40,4 +45,78 @@ p {
   padding: 0 20px;
   text-align: left;
   width: 90%;
+}
+table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 0.9em;
+}
+table tr:nth-child(odd) {
+  background-color: #F6F4F0;
+}
+table tr:nth-child(even) {
+  background-color: #ffffff;
+}
+table th {
+  color: #ffffff;
+  background-color: #555555;
+  border: 1px solid #555555;
+  padding: 3px;
+  vertical-align: top;
+  text-align: left;
+}
+table th a:link,table th a:visited {
+  color: #ffffff;
+}
+table th a:hover, table th a:active {
+  color: #EE872A;
+}
+table td {
+  border: 1px solid #d4d4d4;
+  padding: 5px;
+  padding-top: 7px;
+  padding-bottom: 7px;
+  vertical-align: top;
+  white-space: nowrap;
+}
+table a:link, table a:visited {
+  color: #000;
+  background-color: transparent;
+}
+table a:hover {
+  white-space: nowrap;
+  color: #00a400;
+  background-color: transparent;
+}
+
+.hostBox {
+  margin-left: 2em;
+  margin-bottom: 2em;
+}
+.archiveLink {
+  float: right;
+  font-size: 0.9em;
+}
+.archiveLink:hover {
+  color: #00a400;
+  background-color: transparent;
+}
+.dlBox {
+  margin-bottom: 0.6em;
+  margin-top: 0.6em;
+}
+.dlTarget {
+  font-weight: bold;
+  font-size: 0.9em;
+}
+.dlBox th {
+  width: 1%;
+  white-space: nowrap;
+  padding-right: 2.5em;
+}
+.dlBox .dlHostCol {
+  width: 15%;
+}
+.dlBox .dlCommentCol {
+  width: auto;
 }


### PR DESCRIPTION
I uploaded the first set of downloads via scp. It seems I can't change the ownership of the files, is that an issue @ibuclaw? I also moved the mingw files I hope there were no public links to the old location, but I don't think the new location on gdcproject.org was ever announced?

The page is auto-generated by using this mustache-file:
https://gist.github.com/jpf91/9464455

The windows builds are unfortunately almost unusable (gdc links to -`lrt`, `-lpthread` which are not available, phobos doesn't build), but it can be used with a custom object.d file and -nostdlib so it's not completely useless.
The great thing is that these builds are all done automatically on a x86_64 qemu vm, even the windows->windows ones (these are built as cross-native compilers, a special case of canadian cross compilers).

@ibuclaw if you merge this it might be a good idea to announce this on D.announce to get some attention ;-)

Binaries for the ARM beta will follow later this week.

@venix1 do you have any updated mingw downloads you want published on gdcproject.org?
